### PR TITLE
Fix in laravel 5.4+

### DIFF
--- a/src/Kendu/Mpdf/ServiceProvider.php
+++ b/src/Kendu/Mpdf/ServiceProvider.php
@@ -25,7 +25,7 @@ class ServiceProvider extends BaseServiceProvider {
     public function register()
     {
         $this->app->bind('mpdf.wrapper', function($app,$cfg)  {
-            $app['mpdf.pdf'] = $app->share(function($app) use($cfg){
+            $app['mpdf.pdf'] = $app->singleton(function($app) use($cfg){
 
                     if( ! empty($cfg))
                     {


### PR DESCRIPTION
The share method from the container was removed in Laravel 5.4
https://laravel.com/docs/5.4/upgrade